### PR TITLE
Remove `test` annotations

### DIFF
--- a/tests/AiFactoryCommandConsoleTest.php
+++ b/tests/AiFactoryCommandConsoleTest.php
@@ -16,7 +16,6 @@ class AiFactoryCommandConsoleTest extends BaseTest
         return [LaravelIntelliDbServiceProvider::class];
     }
 
-    /** @test */
     public function test_ai_factory_command_is_registered()
     {
         $kernel = $this->app->make(Kernel::class);
@@ -26,7 +25,6 @@ class AiFactoryCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('ai:factory', $commandList);
     }
 
-    /** @test */
     public function test_ai_factory_command_options()
     {
         $command = $this->app->make(AiFactoryCommand::class);
@@ -38,7 +36,6 @@ class AiFactoryCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('model', $options);
     }
 
-    /** @test */
     public function test_ai_factory_command()
     {
         // Create a model for the purpose of the test

--- a/tests/AiMigrationCommandConsoleTest.php
+++ b/tests/AiMigrationCommandConsoleTest.php
@@ -17,7 +17,6 @@ class AiMigrationCommandConsoleTest extends BaseTest
         return [LaravelIntelliDbServiceProvider::class];
     }
 
-    /** @test */
     public function test_ai_migration_command_is_registered()
     {
         $kernel = $this->app->make(Kernel::class);
@@ -27,7 +26,6 @@ class AiMigrationCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('ai:migration', $commandList);
     }
 
-    /** @test */
     public function test_ai_migration_command_options()
     {
         $command = $this->app->make(AiMigrationCommand::class);
@@ -42,7 +40,6 @@ class AiMigrationCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('path', $options);
     }
 
-    /** @test */
     public function test_ai_migration_command()
     {
         $this->artisan('ai:migration', [

--- a/tests/AiModelCommandConsoleTest.php
+++ b/tests/AiModelCommandConsoleTest.php
@@ -16,7 +16,6 @@ class AiModelCommandConsoleTest extends BaseTest
         return [LaravelIntelliDbServiceProvider::class];
     }
 
-    /** @test */
     public function test_ai_model_command_is_registered()
     {
         $kernel = $this->app->make(Kernel::class);
@@ -26,7 +25,6 @@ class AiModelCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('ai:model', $commandList);
     }
 
-    /** @test */
     public function test_ai_model_command_options()
     {
         $command = $this->app->make(AiFactoryCommand::class);
@@ -36,7 +34,6 @@ class AiModelCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('name', $arguments);
     }
 
-    /** @test */
     public function test_ai_model_command()
     {
         $this->artisan('ai:model', ['name' => 'User'])

--- a/tests/AiRuleCommandConsoleTest.php
+++ b/tests/AiRuleCommandConsoleTest.php
@@ -16,7 +16,6 @@ class AiRuleCommandConsoleTest extends BaseTest
         return [LaravelIntelliDbServiceProvider::class];
     }
 
-    /** @test */
     public function test_ai_rule_command_is_registered()
     {
         $kernel = $this->app->make(Kernel::class);
@@ -26,7 +25,6 @@ class AiRuleCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('ai:rule', $commandList);
     }
 
-    /** @test */
     public function test_ai_rule_command_options()
     {
         $command = $this->app->make(AiRuleCommand::class);
@@ -38,7 +36,6 @@ class AiRuleCommandConsoleTest extends BaseTest
         $this->assertArrayHasKey('description', $options);
     }
 
-    /** @test */
     public function test_ai_rule_command()
     {
         $this->artisan('ai:model', ['name' => 'User'])


### PR DESCRIPTION
No need to add `test` annotation when use test_ prefix.